### PR TITLE
Automatically Build DebugAPK for test

### DIFF
--- a/.github/workflows/build_debug.yml
+++ b/.github/workflows/build_debug.yml
@@ -1,0 +1,26 @@
+name: Build DebugAPK
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build_apk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: 17
+          distribution: 'adopt'
+          cache: gradle
+      - name: Build with Gradle
+        run: ./gradlew assembleDebug     
+      - name: Upload files for Download
+        uses: actions/upload-artifact@v2
+        with:
+          name: Build
+          path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
This automatically builds debug_apk for testing.

The APK created by this workflow is not signed but it can be, though it needs you to create some GitHub secrets (I can help you with that if you want to). Since these are just for testing I don't think it is that necessary but if you want to you can do ut or ask me for help with it