### PR TITLE
Custom color selector for Monet colors

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,4 +71,5 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui:2.5.1'
 
     implementation 'com.google.android.material:material:1.7.0-alpha03'
+    implementation 'com.github.yukuku:ambilwarna:2.0.1'
 }

--- a/app/src/main/java/xyz/zedler/patrick/doodle/fragment/AppearanceFragment.java
+++ b/app/src/main/java/xyz/zedler/patrick/doodle/fragment/AppearanceFragment.java
@@ -413,7 +413,7 @@ public class AppearanceFragment extends BaseFragment
 
         SelectionCardView card = new SelectionCardView(activity);
         card.setScrimEnabled(true, false);
-        card.setCardImageResource(wallpaper.getThumbnailResId());
+        card.setCardImageResource(wallpaper.getThumbnailResId(), false);
         card.setOnClickListener(v -> {
           if (randomWallpaper) {
             if (card.isChecked() && randomList.size() == 1) {
@@ -726,11 +726,21 @@ public class AppearanceFragment extends BaseFragment
     activity.showSnackbar(activity.getSnackbar(R.string.msg_apply_colors, Snackbar.LENGTH_LONG));
   }
 
-  public void setColor(int priority, String color) {
+  public String getColor(int priority, boolean custom) {
     String pref = Constants.getThemeColorPref(
-        currentWallpaper.getName(), currentVariantIndex, priority, isWallpaperNightMode()
+      currentWallpaper.getName(), currentVariantIndex, priority, isWallpaperNightMode()
+    ) + (custom ? "_custom" : "");
+    return getSharedPrefs().getString(pref, "#000000");
+  }
+
+  public void setColor(int priority, String color, boolean custom) {
+    String pref = Constants.getThemeColorPref(
+      currentWallpaper.getName(), currentVariantIndex, priority, isWallpaperNightMode()
     );
     getSharedPrefs().edit().putString(pref, color).apply();
+    if (custom)  {
+      getSharedPrefs().edit().putString(pref + "_custom", color).apply();
+    }
     refreshColor(priority, true);
     activity.requestThemeRefresh();
     showMonetInfoIfRequired();

--- a/app/src/main/java/xyz/zedler/patrick/doodle/view/SelectionCardView.java
+++ b/app/src/main/java/xyz/zedler/patrick/doodle/view/SelectionCardView.java
@@ -21,12 +21,15 @@ package xyz.zedler.patrick.doodle.view;
 
 import android.content.Context;
 import android.content.res.ColorStateList;
+import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
+import androidx.core.content.res.ResourcesCompat;
+
 import com.google.android.material.card.MaterialCardView;
 import com.google.android.material.color.ColorRoles;
 import com.google.android.material.color.MaterialColors;
@@ -99,7 +102,7 @@ public class SelectionCardView extends MaterialCardView {
     }
   }
 
-  public void setCardImageResource(@DrawableRes int resId) {
+  public void setCardImageResource(@DrawableRes int resId, boolean tint) {
     innerCard.removeAllViews();
     ImageView image = new ImageView(getContext());
     image.setLayoutParams(
@@ -107,6 +110,13 @@ public class SelectionCardView extends MaterialCardView {
             ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
         )
     );
+    Drawable drawable = ResourcesCompat.getDrawable(
+            getResources(), resId, null
+    );
+    if (tint && drawable != null) {
+      drawable.setTint(ResUtil.getColorAttr(getContext(), R.attr.colorOutline));
+    }
+    image.setImageDrawable(drawable);
     image.setImageResource(resId);
     innerCard.addView(image);
   }

--- a/app/src/main/res/drawable/ic_round_add_color.xml
+++ b/app/src/main/res/drawable/ic_round_add_color.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ This file is part of Doodle Android.
+  ~
+  ~ Doodle Android is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ Doodle Android is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with Doodle Android. If not, see <http://www.gnu.org/licenses/>.
+  ~
+  ~ Copyright (c) 2019-2022 by Patrick Zedler
+  -->
+
+<vector
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="24"
+  android:viewportHeight="24">
+  <path
+    android:fillColor="#000"
+    android:pathData="M12.0048,5.9567313 c -0.374473,0 -0.676933,0.3024603 -0.676933,0.6769349 L 11.323038,11.3242 H 6.6277301 c -0.3744746,0 -0.6769347,0.302461 -0.6769347,0.676935 0,0.374475 0.3024601,0.676935 0.6769347,0.676935 h 4.6953339 v 4.695335 c 0,0.374474 0.302461,0.676935 0.676936,0.676935 0.374474,0 0.676935,-0.302461 0.676935,-0.676935 V 12.67807 h 4.695335 c 0.374474,0 0.676934,-0.30246 0.676934,-0.676935 0,-0.374474 -0.30246,-0.676935 -0.676934,-0.676935 H 12.676935 V 6.6288652 c 0,-0.3648727 -0.307262,-0.6721339 -0.672135,-0.6721339z" />
+</vector>

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 


### PR DESCRIPTION
An implementation for issue #60 to choose custom colors for Material You

Under the extracted colors subsection in Appearance, a new choice has been added that when tapped will open [AmbilWarna Color Picker](https://github.com/yukuku/ambilwarna) and let the user pick custom colors for the theming

I don't know how good this implementation is, but it seems to work fine and will at least be a good starting point